### PR TITLE
Fix of showing name in leaderboard

### DIFF
--- a/src/Components/MemoryGame.jsx
+++ b/src/Components/MemoryGame.jsx
@@ -207,7 +207,7 @@ const MemoryGame = () => {
                 <ul className="leaderboard">
                   {leaderboard.map((entry, index) => (
                     <li key={entry.id}>
-                      {index + 1}. {entry.name} — {entry.moves} moves, {entry.time}s
+                      {index + 1}. {entry.player_name} — {entry.moves} moves, {entry.time}s
               </li>
             ))}
           </ul>


### PR DESCRIPTION
Changed name to player_name in the leaderboard, so that we can display the name